### PR TITLE
Document unsupported formats

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,8 +35,10 @@ toIco(files).then(buf => {
 
 Type: `Array` `string`
 
-An array of PNG image buffers. The images must have a size of `16x16`, `24x24`, `32x32`, `48x48`, `64x64`, `128x128` or `256x256` and they must have an 8 bit per sample (channel) bit-depth (on Unix you can check this with the `file` command: RGB(A) is supported, while [colormap](https://en.wikipedia.org/wiki/Indexed_color) is not, because it's 8 bits per pixel instead of 8 bits per channel, which is 24 or 32 bits per pixel depending on the presence of the alpha channel). Also, interlaced PNGs aren't supported.
-These are limitations in the underlying [pngjs](https://github.com/niegowski/node-pngjs#documentation) library. If you have a colormap PNG you can convert it to an RGB/RGBA PNG with commonly used image editing tools.
+Array of PNG image buffers.
+
+The images must have a size of `16x16`, `24x24`, `32x32`, `48x48`, `64x64`, `128x128` or `256x256` and they must have an 8 bit per sample (channel) bit-depth (on Unix you can check this with the `file` command: RGB(A) is supported, while [colormap](https://en.wikipedia.org/wiki/Indexed_color) is not, because it's 8 bits per pixel instead of 8 bits per channel, which is 24 or 32 bits per pixel depending on the presence of the alpha channel). Also, interlaced PNGs aren't supported.
+These are limitations in the underlying [`pngjs`](https://github.com/niegowski/node-pngjs#documentation) library. If you have a colormap PNG you can convert it to an RGB/RGBA PNG with commonly used image editing tools.
 
 #### options
 

--- a/readme.md
+++ b/readme.md
@@ -37,8 +37,7 @@ Type: `Array` `string`
 
 Array of PNG image buffers.
 
-The images must have a size of `16x16`, `24x24`, `32x32`, `48x48`, `64x64`, `128x128` or `256x256` and they must have an 8 bit per sample (channel) bit-depth (on Unix you can check this with the `file` command: RGB(A) is supported, while [colormap](https://en.wikipedia.org/wiki/Indexed_color) is not, because it's 8 bits per pixel instead of 8 bits per channel, which is 24 or 32 bits per pixel depending on the presence of the alpha channel). Also, interlaced PNGs aren't supported.
-These are limitations in the underlying [`pngjs`](https://github.com/niegowski/node-pngjs#documentation) library. If you have a colormap PNG you can convert it to an RGB/RGBA PNG with commonly used image editing tools.
+The images must have a size of `16x16`, `24x24`, `32x32`, `48x48`, `64x64`, `128x128` or `256x256` and they must have an 8 bit per sample (channel) bit-depth (on Unix you can check this with the `file` command: RGB(A) is supported, while [colormap](https://en.wikipedia.org/wiki/Indexed_color) is not, because it's 8 bits per pixel instead of 8 bits per channel, which is 24 or 32 bits per pixel depending on the presence of the alpha channel). Also, interlaced PNGs aren't supported. These are limitations in the underlying [`pngjs`](https://github.com/niegowski/node-pngjs#documentation) library. If you have a colormap PNG you can convert it to an RGB/RGBA PNG with commonly used image editing tools.
 
 #### options
 

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,8 @@ toIco(files).then(buf => {
 
 Type: `array`
 
-An array of PNG image buffers. The images must have a size of `16x16`, `24x24`, `32x32`, `48x48`, `64x64`, `128x128` or `256x256`.
+An array of PNG image buffers. The images must have a size of `16x16`, `24x24`, `32x32`, `48x48`, `64x64`, `128x128` or `256x256` and they must have an 8 bit per sample (channel) bit-depth (on Unix you can check this with the `file` command: RGB(A) is supported, while [colormap](https://en.wikipedia.org/wiki/Indexed_color) is not, because it's 8 bits per pixel instead of 8 bits per channel, which is 24 or 32 bits per pixel depending on the presence of the alpha channel). Also, interlaced PNGs aren't supported.
+These are limitations in the underlying [pngjs](https://github.com/niegowski/node-pngjs#documentation) library. If you have a colormap PNG you can convert it to an RGB/RGBA PNG with commonly used image editing tools.
 
 
 ## License


### PR DESCRIPTION
After failing to convert a png to ico (I was getting an ico with pixels of random colors), I did some research and I found out that my image was in the indexed colormap format (8 bits per _pixel_), while [pngjs only supports 8 bits per _channel_ depth](https://github.com/niegowski/node-pngjs#documentation). I suggest adding this to the readme so users can find this out without needing to digg in the documentation of the underlying modules.
